### PR TITLE
Increase compatibility with older ansible versions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,5 +13,5 @@ test:
       - >
         wget -qO- bit.ly/ansibletest | env
         DOCKER_IMAGES="ubuntu:16.04"
-        ANSIBLE_VERSIONS="1.6.1 1.7.2 1.8.4 1.9.2 2.0.0.2 2.1.0.0"
+        ANSIBLE_VERSIONS="1.4.4 1.5.4 1.6.1 1.7.2 1.8.4 1.9.2 2.0.0.2 2.1.0.0"
         sh

--- a/tasks/include_vars.yml
+++ b/tasks/include_vars.yml
@@ -1,0 +1,11 @@
+---
+- debug: var=ansible_distribution
+- debug: var=ansible_distribution_version
+- debug: msg="{{ansible_distribution_version|int}}"
+
+- include_vars: "{{item}}"
+  with_first_found:
+  - "../vars/{{ansible_distribution}}-{{ansible_distribution_version|int}}.yml"
+  - "../vars/{{ansible_distribution}}.yml"
+  - "../vars/{{ansible_os_family}}.yml"
+  - "../vars/default.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,13 @@
 ---
 - include: compat.yml
 
+- include: include_vars.yml
+
 - include: Debian.yml
   when: ansible_os_family == 'Debian'
 
 - include: RedHat.yml
   when: ansible_os_family == 'RedHat'
-
-- include_vars: "{{item}}"
-  with_first_found:
-  - "../vars/{{ansible_distribution}}-{{ansible_distribution_major_version | int}}.yml"
-  - "../vars/{{ansible_distribution}}.yml"
-  - "../vars/{{ansible_os_family}}.yml"
-  - "../vars/default.yml"
 
 - include: install_package_names.yml
 


### PR DESCRIPTION
Switch ansible_distribution_major_version to
ansible_distribution_version.  Extract file include_vars.yml
